### PR TITLE
Add SSL pins and trackVerifiedAutoFailover docs for failover domain, configurable network timeout

### DIFF
--- a/geofencing/fraud.mdx
+++ b/geofencing/fraud.mdx
@@ -208,7 +208,7 @@ To enable SSL pinning and prevent man-in-the-middle attacks, add a `res/xml/netw
         </pin-set>
     </domain-config>
 
-    <!-- for SSL pinning (failover) -->
+    <!-- for SSL pinning (if using failover) -->
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="true">api-verified.radar.com</domain>
         <pin-set>
@@ -300,6 +300,7 @@ To enable SSL pinning and prevent man-in-the-middle attacks, add the following t
                 </dict>
             </array>
         </dict>
+        <!-- Needed if using failover -->
         <key>api-verified.radar.com</key>
         <dict>
             <key>NSIncludesSubdomains</key>

--- a/geofencing/fraud.mdx
+++ b/geofencing/fraud.mdx
@@ -192,6 +192,18 @@ To enable SSL pinning and prevent man-in-the-middle attacks, add a `res/xml/netw
             <pin digest="SHA-256">15ktYXSSU2llpy7YyCgeqUKDBkjcimK/weUcec960sI=</pin>
         </pin-set>
     </domain-config>
+
+    <!-- for SSL pinning (failover) -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">api-verified.radar.com</domain>
+        <pin-set>
+            <pin digest="SHA-256">++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</pin>
+            <pin digest="SHA-256">f0KW/FtqTjs108NpYj42SrGvOB2PpxIVM8nWxjPqJGE=</pin>
+            <pin digest="SHA-256">NqvDJlas/GRcYbcWE8S/IceH9cq77kg0jVhZeAPXq8k=</pin>
+            <pin digest="SHA-256">9+ze1cZgR9KO1kZrVDxA4HQ6voHRCSVNz4RdTCx4U8U=</pin>
+            <pin digest="SHA-256">KwccWaCgrnaw6tsrrSO61FgLacNgG2MMLq8GE6+oP5I=</pin>
+        </pin-set>
+    </domain-config>
 </network-security-config>
 ```
 
@@ -250,6 +262,34 @@ To enable SSL pinning and prevent man-in-the-middle attacks, add the following t
                 <dict>
                     <key>SPKI-SHA256-BASE64</key>
                     <string>15ktYXSSU2llpy7YyCgeqUKDBkjcimK/weUcec960sI=</string>
+                </dict>
+            </array>
+        </dict>
+        <key>api-verified.radar.com</key>
+        <dict>
+            <key>NSIncludesSubdomains</key>
+            <true/>
+            <key>NSPinnedCAIdentities</key>
+            <array>
+                <dict>
+                    <key>SPKI-SHA256-BASE64</key>
+                    <string>++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</string>
+                </dict>
+                <dict>
+                    <key>SPKI-SHA256-BASE64</key>
+                    <string>f0KW/FtqTjs108NpYj42SrGvOB2PpxIVM8nWxjPqJGE=</string>
+                </dict>
+                <dict>
+                    <key>SPKI-SHA256-BASE64</key>
+                    <string>NqvDJlas/GRcYbcWE8S/IceH9cq77kg0jVhZeAPXq8k=</string>
+                </dict>
+                <dict>
+                    <key>SPKI-SHA256-BASE64</key>
+                    <string>9+ze1cZgR9KO1kZrVDxA4HQ6voHRCSVNz4RdTCx4U8U=</string>
+                </dict>
+                <dict>
+                    <key>SPKI-SHA256-BASE64</key>
+                    <string>KwccWaCgrnaw6tsrrSO61FgLacNgG2MMLq8GE6+oP5I=</string>
                 </dict>
             </array>
         </dict>

--- a/geofencing/fraud.mdx
+++ b/geofencing/fraud.mdx
@@ -154,7 +154,7 @@ Radar.initialize(
 )
 ```
 
-To enable automatic failover to a secondary verified host if the primary returns a non-Radar response (e.g., due to DNS hijacking or interception), also pass `trackVerifiedAutoFailover = true`:
+To enable automatic failover to a secondary verified host if the primary host is erroring, also pass `trackVerifiedAutoFailover = true`:
 
 ```java
 val options = RadarInitializeOptions(
@@ -247,7 +247,7 @@ If you do not install the plugin, `Radar.trackVerified()` will return `ERROR_PLU
 
 #### Initialize SDK
 
-To enable automatic failover to a secondary verified host if the primary returns a non-Radar response (e.g., due to DNS hijacking or interception), set `trackVerifiedAutoFailover` on `RadarInitializeOptions`:
+To enable automatic failover to a secondary verified host if the primary host is erroring, also pass `trackVerifiedAutoFailover = true`, set `trackVerifiedAutoFailover` on `RadarInitializeOptions`:
 
 <CodeGroup>
 

--- a/geofencing/fraud.mdx
+++ b/geofencing/fraud.mdx
@@ -142,18 +142,6 @@ If you do not install the plugin, `Radar.trackVerified()` will return `ERROR_PLU
 
 To support the `sharing` flag on Android, pass `fraud = true` to `RadarInitializeOptions` in `Radar.initialize()`.
 
-```java
-val options = RadarInitializeOptions(
-  fraud = true
-)
-
-Radar.initialize(
-  context = this,
-  publishableKey = "prj_test_pk_...",
-  options = options
-)
-```
-
 To enable automatic failover to a secondary verified host if the primary host is erroring, also pass `trackVerifiedAutoFailover = true`:
 
 ```java

--- a/geofencing/fraud.mdx
+++ b/geofencing/fraud.mdx
@@ -154,6 +154,21 @@ Radar.initialize(
 )
 ```
 
+To enable automatic failover to a secondary verified host if the primary returns a non-Radar response (e.g., due to DNS hijacking or interception), also pass `trackVerifiedAutoFailover = true`:
+
+```java
+val options = RadarInitializeOptions(
+  fraud = true,
+  trackVerifiedAutoFailover = true
+)
+
+Radar.initialize(
+  context = this,
+  publishableKey = "prj_test_pk_...",
+  options = options
+)
+```
+
 #### Play Integrity API
 
 To support the `compromised` flag on Android, enable the [Play Integrity API](https://developer.android.com/google/play/integrity) on the [Settings page](https://dashboard.radar.com/settings#fraud-settings).
@@ -229,6 +244,26 @@ If using [iOS SDK](/sdk/ios) version `3.26.0` or higher, you must install an add
 In Xcode, go to _File \> Swift Packages \> Add Package Dependency_. Enter `https://github.com/radarlabs/radar-sdk-ios-fraud-spm.git` for the _Package Repository URL_.
 
 If you do not install the plugin, `Radar.trackVerified()` will return `ERROR_PLUGIN`.
+
+#### Initialize SDK
+
+To enable automatic failover to a secondary verified host if the primary returns a non-Radar response (e.g., due to DNS hijacking or interception), set `trackVerifiedAutoFailover` on `RadarInitializeOptions`:
+
+<CodeGroup>
+
+```swift Swift
+let radarInitializeOptions = RadarInitializeOptions()
+radarInitializeOptions.trackVerifiedAutoFailover = true
+Radar.initialize(publishableKey: "prj_test_pk_...", options: radarInitializeOptions)
+```
+
+```c Objective-C
+RadarInitializeOptions *radarInitializeOptions = [[RadarInitializeOptions alloc] init];
+radarInitializeOptions.trackVerifiedAutoFailover = YES;
+[Radar initializeWithPublishableKey:@"prj_test_pk_..." options:radarInitializeOptions];
+```
+
+</CodeGroup>
 
 #### App Attest
 

--- a/geofencing/fraud.mdx
+++ b/geofencing/fraud.mdx
@@ -235,7 +235,7 @@ If you do not install the plugin, `Radar.trackVerified()` will return `ERROR_PLU
 
 #### Initialize SDK
 
-To enable automatic failover to a secondary verified host if the primary host is erroring, also pass `trackVerifiedAutoFailover = true`, set `trackVerifiedAutoFailover` on `RadarInitializeOptions`:
+To enable automatic failover of `trackVerified()` requests to a secondary host if the primary host is unreachable, set `trackVerifiedAutoFailover = true` on `RadarInitializeOptions`:
 
 <CodeGroup>
 

--- a/geofencing/fraud.mdx
+++ b/geofencing/fraud.mdx
@@ -142,7 +142,7 @@ If you do not install the plugin, `Radar.trackVerified()` will return `ERROR_PLU
 
 To support the `sharing` flag on Android, pass `fraud = true` to `RadarInitializeOptions` in `Radar.initialize()`.
 
-To enable automatic failover to a secondary verified host if the primary host is erroring, also pass `trackVerifiedAutoFailover = true`:
+To enable automatic failover of `trackVerified()` requests to a secondary host if the primary host is unreachable, pass `trackVerifiedAutoFailover = true`:
 
 ```java
 val options = RadarInitializeOptions(

--- a/sdk/android.mdx
+++ b/sdk/android.mdx
@@ -82,6 +82,19 @@ class MyApplication : Application() {
 
 </CodeGroup>
 
+### Network timeout
+
+To override the default network timeout, set `networkTimeout` on `RadarInitializeOptions` as a Kotlin `Duration`. The extended timeout used for longer-running requests is automatically set to 2.5x this value. Values are clamped to `[1, 300]` seconds.
+
+```kotlin Kotlin
+import io.radar.sdk.Radar
+import io.radar.sdk.RadarInitializeOptions
+import kotlin.time.Duration.Companion.seconds
+
+val options = RadarInitializeOptions(networkTimeout = 30.seconds)
+Radar.initialize(this, "prj_test_pk_...", options)
+```
+
 ## Request permissions
 
 Radar respects [standard Android location permissions](https://developer.android.com/training/permissions/requesting.html).

--- a/sdk/android.mdx
+++ b/sdk/android.mdx
@@ -24,7 +24,7 @@ Add the SDK to the `dependencies` section of your app's `build.gradle` file:
 
 ```gradle
 dependencies {   
-  implementation 'io.radar:sdk:3.25.+'
+  implementation 'io.radar:sdk:3.32.+'
 }
 ```
 

--- a/sdk/ios.mdx
+++ b/sdk/ios.mdx
@@ -21,7 +21,7 @@ The SDK is small and typically adds less than 500 KB to your compiled app.
 Install [CocoaPods](https://cocoapods.org/). If you don't have an existing `Podfile`, run `pod init` in your project directory. Add the following to your `Podfile`:
 
 ```
-pod 'RadarSDK', '~> 3.26.0'
+pod 'RadarSDK', '~> 3.32.0'
 ```
 
 Then, run `pod install`. You may also need to run `pod repo update`.
@@ -35,7 +35,7 @@ In Xcode, go to _File_ \> _Swift Packages_ \> _Add Package Dependency_. Enter `h
 **Note:** we recommend pinning the minor version you're installing as we occasionally introduce breaking changes in new minor versions. You can pin the minor version using the range operator:
 
 ```
-3.26.0..<3.27.0
+3.32.0..<3.33.0
 ```
 
 <Info>

--- a/sdk/ios.mdx
+++ b/sdk/ios.mdx
@@ -108,6 +108,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 </CodeGroup>
 
+### Network timeout
+
+To override the default network timeout, set `networkTimeoutInterval` (in seconds) on `RadarInitializeOptions`. The extended timeout used for longer-running requests is automatically set to 2.5x this value. Values are clamped to `[1, 300]` seconds.
+
+<CodeGroup>
+
+```swift Swift
+let radarInitializeOptions = RadarInitializeOptions()
+radarInitializeOptions.networkTimeoutInterval = 30
+Radar.initialize(publishableKey: "prj_test_pk_...", options: radarInitializeOptions)
+```
+
+
+```c Objective-C
+RadarInitializeOptions *radarInitializeOptions = [[RadarInitializeOptions alloc] init];
+radarInitializeOptions.networkTimeoutInterval = 30;
+[Radar initializeWithPublishableKey:@"prj_test_pk_..." options:radarInitializeOptions];
+```
+
+</CodeGroup>
+
 ## Request permissions
 
 Radar respects [standard iOS location permissions](https://developer.apple.com/documentation/corelocation/requesting_authorization_for_location_services).

--- a/sdk/ios.mdx
+++ b/sdk/ios.mdx
@@ -47,7 +47,7 @@ In Xcode, go to _File_ \> _Swift Packages_ \> _Add Package Dependency_. Enter `h
 Install [Carthage](https://github.com/Carthage/Carthage) by adding the following to your `Cartfile`:
 
 ```
-github "radarlabs/radar-sdk-ios" ~> 3.21.5
+github "radarlabs/radar-sdk-ios" ~> 3.32.0
 ```
 
 Then, run `carthage update` and drag `Build/iOS/RadarSDK.framework` into the _Linked Frameworks and Libraries_ section of your target. Do not add the framework as an input to your `copy-frameworks` run script.
@@ -462,7 +462,7 @@ To collect motionActivity, you must include a value for `Privacy - Motion Usage 
 Add the following to your `Podfile`:
 
 ```
-pod 'RadarSDKMotion', '~> 3.21.5'
+pod 'RadarSDKMotion', '~> 3.32.0'
 ```
 
 or add the `RadarSDKMotion` package product to your target via SPM.


### PR DESCRIPTION
**https://linear.app/radarlabs/issue/FENCE-2800/update-public-docs-with-new-pins-for-cloudfront**

## Summary

- Adds SSL certificate pins for the new `api-verified.radar.com` failover domain (Android and iOS)
- Documents the new `trackVerifiedAutoFailover` initialization option for Android and iOS

## Related PRs

- https://github.com/radarlabs/radar-sdk-android/pull/508
- https://github.com/radarlabs/radar-sdk-ios/pull/582

## Test plan

https://radarlabs-add-ssl-pins.mintlify.app/geofencing/fraud

- [ ] Verify Android SSL pinning block for `api-verified.radar.com` renders correctly in docs
- [ ] Verify iOS SSL pinning block for `api-verified.radar.com` renders correctly in docs
- [ ] Verify Android `trackVerifiedAutoFailover` init example renders correctly
- [ ] Verify iOS `trackVerifiedAutoFailover` init example renders correctly (Swift + Obj-C tabs)