### PR TITLE
add expo config to deeplink docs

### DIFF
--- a/geofencing/campaigns.mdx
+++ b/geofencing/campaigns.mdx
@@ -555,11 +555,33 @@ func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive respo
 
 #### React Native setup
 
-##### iOS
+###### Using the Expo plugin (recommended)
+If you are using Expo, the `react-native-radar` plugin can set up automatic deep link handling and conversion logging for you at prebuild time. Add the relevant options to your plugin configuration in `app.json`:
+```json
+{
+  "expo": {
+    ...
+    "plugins": [
+      [
+        "react-native-radar",
+        {
+          // boolean to enable iOS automatic deep link handling for Radar notifications, defaults to false
+          "iosAutoHandleNotificationDeepLinks": true,
+          // boolean to enable iOS automatic logging of notification conversions, defaults to false
+          "iosAutoLogNotificationConversions": true
+        }
+      ]
+    ]
+  }
+}
+```
 
-Radar's React Native SDK can automatically set up deep linking for you. To enable this feature, set the `autoHandleNotificationDeepLinks` option to `true` in the `radarInitializeOptions` via the `AppDelegate.mm`.
+Then run `npx expo prebuild --clean` to regenerate the native iOS project. The plugin will inject the required `Radar.nativeSetup(...)` call into your AppDelegate so that deep linking and conversion logging are configured before the JavaScript bundle loads.
 
-```c#
+###### Manual setup (bare React Native)
+If you are not using Expo, set the autoHandleNotificationDeepLinks option to true in the radarInitializeOptions and call [Radar nativeSetup:] from your AppDelegate.mm:
+
+```objc
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   self.moduleName = @"main";

--- a/geofencing/campaigns.mdx
+++ b/geofencing/campaigns.mdx
@@ -576,10 +576,10 @@ If you are using Expo, the `react-native-radar` plugin can set up automatic deep
 }
 ```
 
-Then run `npx expo prebuild --clean` to regenerate the native iOS project. The plugin will inject the required `Radar.nativeSetup(...)` call into your AppDelegate so that deep linking and conversion logging are configured before the JavaScript bundle loads.
+Then run `npx expo prebuild --clean` to regenerate the native iOS project. The plugin will inject the required `Radar.nativeSetup(...)` call into your `AppDelegate.mm` so that deep linking and conversion logging are configured before the JavaScript bundle loads.
 
 ###### Manual setup (bare React Native)
-If you are not using Expo, set the autoHandleNotificationDeepLinks option to true in the radarInitializeOptions and call [Radar nativeSetup:] from your AppDelegate.mm:
+If you are not using Expo, set the `autoHandleNotificationDeepLinks` option to true in `radarInitializeOptions` and call `[Radar nativeSetup:]` from your `AppDelegate.mm`:
 
 ```objc
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions

--- a/sdk/react-native.mdx
+++ b/sdk/react-native.mdx
@@ -68,6 +68,10 @@ You can also use our Expo plugin to take care of the native setup. Add `react-na
           "iosNSLocationAlwaysAndWhenInUseUsageDescription": "Your background location usage description.",
           // boolean to enable iOS background location mode, required for .presetContinuous and .presetResponsive, defaults to false
           "iosBackgroundMode": true,
+          // boolean to enable automatic deep link handling for Radar notification taps on iOS, defaults to false
+          "iosAutoHandleNotificationDeepLinks": true,
+          // boolean to enable automatic conversion logging for Radar notification taps on iOS, defaults to false
+          "iosAutoLogNotificationConversions": true,
           // boolean to enable Android fraud detection, defaults to false
           "androidFraud": true,
           // boolean to enable Android background location permissions, defaults to false


### PR DESCRIPTION
- adds Expo config to deeplink docs
- adds app.json plugin updates to react-native docs
- [FENCE-2791](https://linear.app/radarlabs/issue/FENCE-2791/add-autohandlenotificationdeeplink-config-plugin-to-react-native)