### PR TITLE
Bump iOS SDK to 3.39.0 and Android SDK to 3.36.0

### DIFF
--- a/geofencing/fraud.mdx
+++ b/geofencing/fraud.mdx
@@ -131,7 +131,7 @@ Add the plugin to the `dependencies` section of your app's `build.gradle` file:
 
 ```gradle
 dependencies {   
-  implementation 'io.radar:sdk:3.33.+'
+  implementation 'io.radar:sdk:3.36.+'
   implementation 'io.radar:sdk-fraud:1.1.0'
 }
 ```
@@ -232,7 +232,7 @@ If using [iOS SDK](/sdk/ios) version `3.26.0` or higher, you must install an add
 In Xcode, go to _File \> Swift Packages \> Add Package Dependency_. Enter `https://github.com/radarlabs/radar-sdk-ios-fraud-spm.git` for the _Package Repository URL_.
 
 ```text
-.package(url: "https://github.com/radarlabs/radar-sdk-ios-spm.git", "3.34.0"..<"3.35.0")
+.package(url: "https://github.com/radarlabs/radar-sdk-ios-spm.git", "3.39.0"..<"3.40.0")
 .package(url: "https://github.com/radarlabs/radar-sdk-ios-fraud-spm.git", "1.3.0"..<"1.4.0")
 ```
 

--- a/sdk/android.mdx
+++ b/sdk/android.mdx
@@ -24,7 +24,7 @@ Add the SDK to the `dependencies` section of your app's `build.gradle` file:
 
 ```gradle
 dependencies {   
-  implementation 'io.radar:sdk:3.34.+'
+  implementation 'io.radar:sdk:3.36.+'
 }
 ```
 

--- a/sdk/flutter.mdx
+++ b/sdk/flutter.mdx
@@ -71,7 +71,7 @@ On Android, add the Radar Android SDK to the `dependencies` section of your Andr
 
 ```gradle
 dependencies { 
-  implementation 'io.radar:sdk:3.36.+'
+  implementation 'io.radar:sdk:3.18.+'
 }
 ```
 

--- a/sdk/flutter.mdx
+++ b/sdk/flutter.mdx
@@ -71,7 +71,7 @@ On Android, add the Radar Android SDK to the `dependencies` section of your Andr
 
 ```gradle
 dependencies { 
-  implementation 'io.radar:sdk:3.18.+'
+  implementation 'io.radar:sdk:3.36.+'
 }
 ```
 

--- a/sdk/ios.mdx
+++ b/sdk/ios.mdx
@@ -21,7 +21,7 @@ The SDK is small and typically adds less than 500 KB to your compiled app.
 Install [CocoaPods](https://cocoapods.org/). If you don't have an existing `Podfile`, run `pod init` in your project directory. Add the following to your `Podfile`:
 
 ```text
-pod 'RadarSDK', '~> 3.37.1'
+pod 'RadarSDK', '~> 3.39.0'
 ```
 
 Then, run `pod install`. You may also need to run `pod repo update`.
@@ -35,7 +35,7 @@ In Xcode, go to _File_ \> _Swift Packages_ \> _Add Package Dependency_. Enter `h
 **Note:** we recommend pinning the minor version you're installing as we occasionally introduce breaking changes in new minor versions. You can pin the minor version using the range operator:
 
 ```text
-.package(url: "https://github.com/radarlabs/radar-sdk-ios-spm.git", "3.37.1"..<"3.38.0")
+.package(url: "https://github.com/radarlabs/radar-sdk-ios-spm.git", "3.39.0"..<"3.40.0")
 ```
 
 <Info>
@@ -47,7 +47,7 @@ In Xcode, go to _File_ \> _Swift Packages_ \> _Add Package Dependency_. Enter `h
 Install [Carthage](https://github.com/Carthage/Carthage) by adding the following to your `Cartfile`:
 
 ```text
-github "radarlabs/radar-sdk-ios" ~> 3.37.1
+github "radarlabs/radar-sdk-ios" ~> 3.39.0
 ```
 
 Then, run `carthage update` and drag `Build/iOS/RadarSDK.framework` into the _Linked Frameworks and Libraries_ section of your target. Do not add the framework as an input to your `copy-frameworks` run script.

--- a/tutorials/building-a-delivery-tracking-app.mdx
+++ b/tutorials/building-a-delivery-tracking-app.mdx
@@ -37,7 +37,7 @@ In this tutorial, we will build a delivery tracking iOS application which uses [
     Install [CocoaPods](https://cocoapods.org/). If you don't have an existing `Podfile`, run `pod init` in your project directory. Add the following to your `Podfile`:
 
     ```swift
-    pod 'RadarSDK', '~> 3.5.0'
+    pod 'RadarSDK', '~> 3.39.0'
     ```
 
     Then, run `pod install`. You may also need to run `pod repo update`.


### PR DESCRIPTION
## Summary
- Updates core SDK version pins to iOS 3.39.0 / Android 3.36.0 across `sdk/ios.mdx`, `sdk/android.mdx`, `geofencing/fraud.mdx`, `sdk/flutter.mdx`, and `tutorials/building-a-delivery-tracking-app.mdx`
- Leaves independently-versioned companion packages (RadarSDKMotion, sdk-fraud, radar-sdk-ios-fraud-spm, flutter_radar) and historical "requires/deprecated in version X" callouts untouched

## Test plan
- [ ] Confirm 3.39.0 (iOS) and 3.36.0 (Android) are the correct target versions to publish
- [ ] Spot check rendered docs pages for formatting