### PR TITLE
SRE-2913 Update API endpoint rate limits

### DIFF
--- a/api.mdx
+++ b/api.mdx
@@ -352,7 +352,7 @@ Publishable
 
 **Default rate limit**
 
-10 requests per second (contact your customer success manager to increase rate limit)
+100 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -424,7 +424,7 @@ Publishable
 
 **Default rate limit**
 
-10 requests per second (contact your customer success manager to increase rate limit)
+100 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -490,7 +490,7 @@ Publishable
 
 **Default rate limit**
 
-10 requests per second per device
+100 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -564,7 +564,7 @@ Publishable
 
 **Default rate limit**
 
-10 requests per second (contact your customer success manager to increase rate limit)
+100 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -631,7 +631,7 @@ Secret
 
 **Default rate limit**
 
-100 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -685,7 +685,7 @@ Publishable
 
 **Default rate limit**
 
-100 requests per second
+50 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -747,7 +747,7 @@ Publishable
 
 **Default rate limit**
 
-150 requests per second
+50 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -839,7 +839,7 @@ Publishable
 
 **Default rate limit**
 
-100 requests per second
+25 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -904,7 +904,7 @@ Publishable
 
 **Default rate limit**
 
-100 requests per second
+50 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -974,7 +974,7 @@ Publishable
 
 **Default rate limit**
 
-20 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -1233,7 +1233,7 @@ Publishable
 
 **Default rate limit**
 
-10 requests per second (contact your customer success manager to increase rate limit)
+20 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -2557,7 +2557,7 @@ Lists users. Users are sorted descending by `updatedAt`.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -2601,7 +2601,7 @@ Gets a user. The user can be referenced by Radar `_id`, `userId`, or `deviceId`.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -2641,7 +2641,7 @@ Deletes a user. The user can be referenced by Radar `_id`, `userId`, or `deviceI
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -2680,7 +2680,7 @@ Sends a remote track request to a list of users via silent push notifications.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -2807,7 +2807,7 @@ Gets a trip. The trip can be referenced by Radar `_id` or `externalId`.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -2858,7 +2858,7 @@ Lists trips. Trips are sorted descending by `updatedAt`.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -2937,7 +2937,7 @@ Creates a new trip.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -3018,7 +3018,7 @@ On iOS and Android, use the [SDK](https://docs.radar.com/sdk) to update trips.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -3080,7 +3080,7 @@ Deletes a trip. The trip can be referenced by Radar `_id` or `externalId`.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3180,7 +3180,7 @@ Lists geofences. Geofences are sorted descending by `updatedAt`.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -3228,7 +3228,7 @@ Gets a geofence. The geofence can be uniquely referenced by Radar `_id` or by `t
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3293,7 +3293,7 @@ Upserts a geofence. The geofence can be uniquely referenced by `tag` and `extern
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3342,7 +3342,7 @@ Deletes a geofence. The geofence can be uniquely referenced by Radar `_id` or by
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3376,7 +3376,7 @@ Gets users currently in a geofence.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3501,7 +3501,7 @@ Publishable
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Sample request**
 
@@ -3606,7 +3606,7 @@ Lists beacons. Beacons are sorted descending by `createdAt`.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3652,7 +3652,7 @@ Gets a beacon. The beacon can be uniquely referenced by Radar `_id` or by `tag` 
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3710,7 +3710,7 @@ Creates a beacon.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3777,7 +3777,7 @@ Upserts a beacon. The beacon can be uniquely referenced by Radar `_id` or by `ta
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3831,7 +3831,7 @@ Deletes a beacon. The beacon can be uniquely referenced by Radar `_id` or by `ta
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3877,7 +3877,7 @@ Gets your current Places settings.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 
@@ -3932,7 +3932,7 @@ Updates your Places settings.
 
 **Default rate limit**
 
-10 requests per second
+10 requests per second (contact your customer success manager to increase rate limit)
 
 **Authentication level**
 


### PR DESCRIPTION
## Summary

- update the API reference to match the endpoint rate-limit rollout
- correct the default RPS values for 11 documented endpoints
- standardize the customer-success increase guidance across all adjustable default limits above 1 request per second
- remove the obsolete per-device qualifier from the IP geocoding limit while preserving Track's non-increasable device limit

## Source

[Per-Project Per-Endpoint Rate Limits Rollout](https://www.notion.so/radarlabs/Per-Project-Per-Endpoint-Rate-Limits-Rollout-38ee42b18f96813db6d7f281bbaa2926)

## Validation

- `git diff --check`
- reconciled every rollout endpoint against the API reference and updated all matching entries with changed defaults
- verified all 35 default rate-limit entries use the same `increase rate limit` wording
- verified the separate Track `1 request per second per device` limit is unchanged
